### PR TITLE
Fix resource file paths

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
             name: "GhostHandLib",
             path: "GhostHand/GhostHandLib/Classes/",
             resources: [
-                .copy("GhostHand/GhostHandLib/Built_Product/GhostHand.app"),
-                .copy("ghosthand_install.sh")
+                .copy("../Built_Product/GhostHand.app"),
+                .copy("../../../ghosthand_install.sh")
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,11 +20,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "GhostHandLib",
-            path: "GhostHand/GhostHandLib/Classes/",
-            resources: [
-                .copy("../Built_Product/GhostHand.app"),
-                .copy("../../../ghosthand_install.sh")
-            ]
+            path: "GhostHand/GhostHandLib/Classes/"
         )
     ]
 )


### PR DESCRIPTION
package.swift is incorrectly using file paths based off of the root of the project. Indeed it isn't even necessary to copy these files via the package.swift. Better to just remove the lines.

Resolves: https://github.com/mattstanford/GhostHand/issues/2